### PR TITLE
fix: rawBody field passed to render in lieu of body

### DIFF
--- a/files/entry.js
+++ b/files/entry.js
@@ -20,7 +20,7 @@ export async function svelteHandler(event) {
 		method: httpMethod,
 		headers,
 		path,
-		body,
+		rawBody: body,
 		query
 	});
 


### PR DESCRIPTION
The `svelte` route handler was receiving `undefined` for the body, which doesn't break `get`, but does if a body is passed to a handler, like `post`.

`@sveltejs/kit` expects a `rawBody` that it then conditionally parses based on the type of `rawBody` and the `content-type` header:

```javascript
// @sveltejs/kit/ssr.js > response.js
...
return await options.hooks.handle({
			request: {
				...incoming,
				headers,
				body: parse_body(incoming.rawBody, headers), // this line
				params: {},
				locals: {}
			},
...
```

This PR changes the field from `body` to `rawBody`